### PR TITLE
Use lesson setup.md instead of workshop-metadata/setup.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -489,7 +489,10 @@ during the workshop.
 {% remote_include {{lesson_meta}}/setup.md %}
 {% endcapture %}
 {% if content contains "/setup.md" %}
+  {% capture setup %}
   {% remote_include https://raw.githubusercontent.com/{{content | strip}} %}
+  {% endcapture %}
+  {{ setup | split: "---" | last}}
 {% else %}
   {{ content }}
 {% endif %}

--- a/index.md
+++ b/index.md
@@ -485,7 +485,14 @@ during the workshop.
 {% elsif info.carpentry == "lc" %}
 {% include lc/setup.html %}
 {% elsif info.carpentry == "ds" %}
+{% capture content %}
 {% remote_include {{lesson_meta}}/setup.md %}
+{% endcapture %}
+{% if content contains "/setup.md" %}
+  {% remote_include https://raw.githubusercontent.com/{{content | strip}} %}
+{% else %}
+  {{ content }}
+{% endif %}
 {% elsif info.carpentry == "pilot" %}
 Please check the "Setup" page of
 [the lesson site]({{ site.lesson_site }}) for instructions to follow


### PR DESCRIPTION
closes #91 

The code of this PR can be tested with branch [test_remote_setup](https://github.com/esciencecenter-digital-skills/workshop-metadata/tree/test_remote_setup) in workshop-metadata. The workshop page will render the [setup.md in the lesson ds-dl-intro repository](https://github.com/esciencecenter-digital-skills/workshop-metadata/blob/test_remote_setup/ds-dl-intro/setup.md) instead.