### PR TITLE
Add ds-rpackaging to list of curricula

### DIFF
--- a/index.md
+++ b/index.md
@@ -111,7 +111,7 @@ Check DS curriculum
 {% if info.carpentry == "ds" %}
 {% unless info.curriculum == "ds-cr" or info.curriculum == "ds-containers" or info.curriculum == "ds-dl-intro" or info.curriculum == "ds-gpu" or info.curriculum == "ds-parallel" or info.curriculum == "ds-rpackaging" %}
 <div class="alert alert-warning">
-It looks like you are setting up a website for a Digital Skills curriculum but you haven't specified the curriculum type in the <code>_data/data.csv</code> file (current value in <code>_data/data.csv</code>: "<strong>{{ info.curriculum }}</strong>", possible values: <code>ds-cr</code>, <code>ds-containers</code>, <code>ds-dl-intro</code>, <code>ds-gpu</code>, or <code>ds-parallel</code>). After editing this file, you need to run <code>make serve</code> again to see the changes reflected.
+It looks like you are setting up a website for a Digital Skills curriculum but you haven't specified the curriculum type in the <code>_data/data.csv</code> file (current value in <code>_data/data.csv</code>: "<strong>{{ info.curriculum }}</strong>", possible values: <code>ds-cr</code>, <code>ds-containers</code>, <code>ds-dl-intro</code>, <code>ds-gpu</code>, <code>ds-parallel</code> or <code>ds-rpackaging</code>). After editing this file, you need to run <code>make serve</code> again to see the changes reflected.
 </div>
 {% endunless %}
 {% endif %}


### PR DESCRIPTION
## Problem

When using a new curricula type, the website renders a message like:

```
It looks like you are setting up a website for a Digital Skills curriculum but you haven't specified the curriculum type in the _data/data.csv file (current value in _data/data.csv: "ds-rpackaging", possible values: ds-cr, ds-containers, ds-dl-intro, ds-gpu, or ds-parallel). After editing this file, you need to run make serve again to see the changes reflected.
```
## Solution

I've manually added the option `ds-rpackaging` to the list of possible curricula.

## To consider in the future

Consider reading the possible curricula type from the [workshop metadata repo](https://github.com/esciencecenter-digital-skills/workshop-metadata).