### PR TITLE
Changed docker name

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,7 +36,7 @@ carpentry: "ds"
 # swc-inflammation: for Software Carpentry based on the inflammation dataset
 # swc-gapminder: for Software Carpentry based on the Gapminder dataset
 # ds-cr: for Digital Skills Code Refinery
-# ds-containers: for Digital Skills based on Containers Lesson from Incubator
+# ds-docker: for Digital Skills based on Containers Lesson from Incubator
 # ds-dl-intro: for Digital Skills Introduction to Deep Learning
 # ds-gpu: for Digital Skills GPU Programming
 # ds-parallel: for Digital Skills Parallel Programming

--- a/index.md
+++ b/index.md
@@ -109,9 +109,9 @@ Check DS curriculum
 {% endcomment %}
 
 {% if info.carpentry == "ds" %}
-{% unless info.curriculum == "ds-cr" or info.curriculum == "ds-containers" or info.curriculum == "ds-dl-intro" or info.curriculum == "ds-gpu" or info.curriculum == "ds-parallel" or info.curriculum == "ds-rpackaging" %}
+{% unless info.curriculum == "ds-cr" or info.curriculum == "ds-docker" or info.curriculum == "ds-dl-intro" or info.curriculum == "ds-gpu" or info.curriculum == "ds-parallel" or info.curriculum == "ds-rpackaging" %}
 <div class="alert alert-warning">
-It looks like you are setting up a website for a Digital Skills curriculum but you haven't specified the curriculum type in the <code>_data/data.csv</code> file (current value in <code>_data/data.csv</code>: "<strong>{{ info.curriculum }}</strong>", possible values: <code>ds-cr</code>, <code>ds-containers</code>, <code>ds-dl-intro</code>, <code>ds-gpu</code>, <code>ds-parallel</code> or <code>ds-rpackaging</code>). After editing this file, you need to run <code>make serve</code> again to see the changes reflected.
+It looks like you are setting up a website for a Digital Skills curriculum but you haven't specified the curriculum type in the <code>_data/data.csv</code> file (current value in <code>_data/data.csv</code>: "<strong>{{ info.curriculum }}</strong>", possible values: <code>ds-cr</code>, <code>ds-docker</code>, <code>ds-dl-intro</code>, <code>ds-gpu</code>, <code>ds-parallel</code> or <code>ds-rpackaging</code>). After editing this file, you need to run <code>make serve</code> again to see the changes reflected.
 </div>
 {% endunless %}
 {% endif %}


### PR DESCRIPTION
The docker workshop should be called ds-docker. It's named that in all the other material.